### PR TITLE
activate widget by object

### DIFF
--- a/source/demo.d
+++ b/source/demo.d
@@ -73,6 +73,9 @@ version(demo){
 					}else if (key.key == KeyboardEvent.CtrlKeys.CtrlL){
 						log.show = !log.show;
 						log.add("log "~to!dstring(log.show ? "shown" : "hidden"));
+					}else if (key.key == KeyboardEvent.CtrlKeys.CtrlE){
+						log.add("jump to the EditLine");
+						term.activateWidget(edit);
 					}
 				}
 				return false;

--- a/source/qui/qui.d
+++ b/source/qui/qui.d
@@ -534,14 +534,17 @@ protected:
 	/// activate the passed widget if it's in the current layout, return if it was activated or not
 	override bool searchAndActivateWidget(QWidget target){
 		integer lastActiveWidgetIndex = _activeWidgetIndex;
-		for (_activeWidgetIndex = 0; _activeWidgetIndex < _widgets.length; _activeWidgetIndex ++){
-			auto widget = _widgets[_activeWidgetIndex];
-			if (widget.wantsInput && widget.show && widget.searchAndActivateWidget(target))
-				break;
-		}
-		if (_activeWidgetIndex >= _widgets.length)
-			_activeWidgetIndex = -1;
 
+		// search and activate recursively
+		_activeWidgetIndex = -1;
+		foreach (integer index, widget; _widgets) {
+			if (widget.wantsInput && widget.show && widget.searchAndActivateWidget(target)) {
+				_activeWidgetIndex = index;
+				break;
+			}
+		}
+
+		// and then manipulate the current layout
 		if (lastActiveWidgetIndex != _activeWidgetIndex){
 			if (lastActiveWidgetIndex > -1)
 				_widgets[lastActiveWidgetIndex].activateEventCall(false);

--- a/source/qui/qui.d
+++ b/source/qui/qui.d
@@ -185,6 +185,14 @@ protected:
 	bool cycleActiveWidget(){
 		return false;
 	}
+	/// activate the passed widget if this is actually the correct widget, return if it was activated or not
+	bool searchAndActivateWidget(QWidget target) {
+		if (this == target) {
+			this.activateEvent(true);
+			return true;
+		}
+		return false;
+	}
 
 	/// custom onInit event, if not null, it should be called before doing anything else in init();
 	InitFunction _customInitEvent;
@@ -522,6 +530,26 @@ protected:
 		}
 		return _activeWidgetIndex != -1;
 	}
+
+	/// activate the passed widget if it's in the current layout, return if it was activated or not
+	override bool searchAndActivateWidget(QWidget target){
+		integer lastActiveWidgetIndex = _activeWidgetIndex;
+		for (_activeWidgetIndex = 0; _activeWidgetIndex < _widgets.length; _activeWidgetIndex ++){
+			auto widget = _widgets[_activeWidgetIndex];
+			if (widget.wantsInput && widget.show && widget.searchAndActivateWidget(target))
+				break;
+		}
+		if (_activeWidgetIndex >= _widgets.length)
+			_activeWidgetIndex = -1;
+
+		if (lastActiveWidgetIndex != _activeWidgetIndex){
+			if (lastActiveWidgetIndex > -1)
+				_widgets[lastActiveWidgetIndex].activateEventCall(false);
+			if (_activeWidgetIndex > -1)
+				_widgets[_activeWidgetIndex].activateEventCall(true);
+		}
+		return _activeWidgetIndex != -1;
+	}
 public:
 	/// Layout type
 	enum Type{
@@ -807,5 +835,10 @@ public:
 				update();
 			}
 		}
+	}
+
+	/// search the passed widget recursively and activate it, returns if the activation was successful
+	bool activateWidget(QWidget target) {
+		return this.searchAndActivateWidget(target);
 	}
 }


### PR DESCRIPTION
So far it is only possible to activate widgets via the <kbd>Tab</kbd> key. All the activation methods from `QWidget` are private, and the ones from `QLayout` are `protected`. Maybe it's possible to inherit from `QLayout` and hack something together with the protected methods like `activateEvent` or `cycleEvent`, however that's quite cumbersome.

Also, I don't like the tab key very much. It might make sense for some applications, but definitely not for all. E.g. in an application that I'm building right now, I have a horizontal layout with a visible and a hidden widget. When I press a special key I want to show the hidden widget and activate it. If I press another key, I want to hide it again, and jump back to the previously active widget.

Additionally at the start of a `qui` application, no widget is active, and once you iterated over all widgets then for a moment no widget is activated and you have to press <kbd>Tab</kbd> again to reactivate the first widget. Both things are also quite annoying for my purpose.

---

In this pull request I add a new method to activate a widget.
The `QTerminal` object has now a `public bool activateWidget(QWidget target)` method.
This method recursively searches the layouts for the widget, and activates it.
I've also added an example in the `quidemo` application.

The <kbd>Tab</kbd> functionallity is still preserved, this pull request simply adds an additional way of activating widgets.